### PR TITLE
PAN-1572 - remove unused loadFactor parameter

### DIFF
--- a/aurora/amun/client/parameters.py
+++ b/aurora/amun/client/parameters.py
@@ -67,7 +67,6 @@ class LoadFactorBaseParameters:
         - **hubHeight** (float): Given in meters (m).
         - **obstacleHeight** (float): Given in meters (m).
         - **numberOfTurbines** (int): The number of turbines in the site.
-        - **roughnessLength** (float, optional): Static roughness. If not given, will be derived from reanalysis data. Defaults to None.
         - **usePowerCurveSmoothing** (bool, optional): Should Default Multi-Turbine Power Curve Smoothing be used in the calculation if true then a region specific scale factor is used. If None then no smoothing is applied Defaults to None.
         - **smoothingCoefficient** (float): The value to use for smoothing. This will override any region specific values. This has no effect unless *usePowerCurveSmoothing* is true.
         - **lossesWake** (float, default 0): The percentage to apply for wake loss. (0 <= lossesWake < 1)
@@ -88,7 +87,6 @@ class LoadFactorBaseParameters:
         obstacleHeight: float,
         numberOfTurbines: int = None,
         turbineModelId: int = None,
-        roughnessLength: float = None,
         usePowerCurveSmoothing: bool = None,
         smoothingCoefficient: float = None,
         lossesWake: float = 0.0,
@@ -108,7 +106,6 @@ class LoadFactorBaseParameters:
         self.obstacleHeight = obstacleHeight
 
         self.numberOfTurbines = numberOfTurbines
-        self.roughnessLength = roughnessLength
         self.usePowerCurveSmoothing = usePowerCurveSmoothing
 
         self.lossesWake = lossesWake

--- a/docusaurus-site/docs/Examples/01-Load Factors/01-common.md
+++ b/docusaurus-site/docs/Examples/01-Load Factors/01-common.md
@@ -48,7 +48,6 @@ base_parameters = LoadFactorBaseParameters(
     lossesAvailability=0.1,
     lossesWake=0,
     numberOfTurbines=12,
-    roughnessLength=0.02,
     usePowerCurveSmoothing=False
 )
 
@@ -96,7 +95,6 @@ base_parameters = LoadFactorBaseParameters(
     lossesAvailability=0.1,
     lossesWake=0,
     numberOfTurbines=12,
-    roughnessLength=0.02,
     usePowerCurveSmoothing=False
 )
 
@@ -153,7 +151,6 @@ base_parameters = LoadFactorBaseParameters(
     lossesAvailability=0.1,
     lossesWake=0,
     numberOfTurbines=12,
-    roughnessLength=0.02,
     usePowerCurveSmoothing=False
 )
 
@@ -198,7 +195,6 @@ base_parameters = LoadFactorBaseParameters(
     lossesAvailability=0.1,
     lossesWake=0,
     numberOfTurbines=12,
-    roughnessLength=0.02,
     usePowerCurveSmoothing=False
 )
 

--- a/docusaurus-site/docs/Examples/01-Load Factors/02-advanced.md
+++ b/docusaurus-site/docs/Examples/01-Load Factors/02-advanced.md
@@ -35,7 +35,6 @@ base_parameters = LoadFactorBaseParameters(
     lossesAvailability=0.1,
     lossesWake=0,
     numberOfTurbines=12,
-    roughnessLength=0.02,
     usePowerCurveSmoothing=False
 )
 
@@ -93,7 +92,6 @@ base_parameters = LoadFactorBaseParameters(
     lossesAvailability=0.1,
     lossesWake=0,
     numberOfTurbines=12,
-    roughnessLength=0.02,
     usePowerCurveSmoothing=False,
     useReanalysisCorrection=False,
 )

--- a/docusaurus-site/docs/Reference/parameters.md
+++ b/docusaurus-site/docs/Reference/parameters.md
@@ -99,7 +99,6 @@ Parameters for all wind types.
   - **hubHeight** (float): Given in meters (m).
   - **obstacleHeight** (float): Given in meters (m).
   - **numberOfTurbines** (int): The number of turbines in the site.
-  - **roughnessLength** (float, optional): Static roughness. If not given, will be derived from reanalysis data. Defaults to None.
   - **usePowerCurveSmoothing** (bool, optional): Should Default Multi-Turbine Power Curve Smoothing be used in the calculation if true then a region specific scale factor is used. If None then no smoothing is applied Defaults to None.
   - **smoothingCoefficient** (float): The value to use for smoothing. This will override any region specific values. This has no effect unless *usePowerCurveSmoothing* is true.
   - **lossesWake** (float, default 0): The percentage to apply for wake loss. (0 &lt;= lossesWake &lt; 1)

--- a/docusaurus-site/docs/changelog.md
+++ b/docusaurus-site/docs/changelog.md
@@ -4,13 +4,17 @@ title: Changelog
 description: Whats new in the SDK
 ---
 
+## Version 1.0.5 ![Latest](https://img.shields.io/badge/-Latest-ffcc00?style=for-the-badge)
 
-## Version 1.0.4 ![Latest](https://img.shields.io/badge/-Latest-ffcc00?style=for-the-badge)
+_Date: 11-04-2024_
+
+- Remove unused `roughnessLength` parameter from Load Factor API
+
+## Version 1.0.4
 
 _Date: 2-04-2024_
 
 - `LoadFactorBaseParameters` class no longer provides `useReanalysisCorrection` field which in reality only applies to the `BuiltInWindParameters`
-
 
 ## Version 1.0.3
 

--- a/examples/get_load_factors.py
+++ b/examples/get_load_factors.py
@@ -89,7 +89,6 @@ def main():
         lossesAvailability=0.1,
         lossesWake=0,
         numberOfTurbines=12,
-        roughnessLength=0.02,
         usePowerCurveSmoothing=False
     )
 

--- a/examples/get_load_factors_batch.py
+++ b/examples/get_load_factors_batch.py
@@ -28,7 +28,6 @@ def main():
         lossesAvailability=0.1,
         lossesWake=0,
         numberOfTurbines=12,
-        roughnessLength=0.02,
         usePowerCurveSmoothing=False
     )
 

--- a/examples/get_load_factors_with_dictionary.py
+++ b/examples/get_load_factors_with_dictionary.py
@@ -60,7 +60,6 @@ def main():
         "hubHeight": 90,
         "obstacleHeight": 0,
         "numberOfTurbines": 12,
-        "roughnessLength": 0.02,
         "usePowerCurveSmoothing": False,
         # Optional
         # "lossesWake": 0.2,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="aurora-amun-sdk",
-    version="1.0.4",
+    version="1.0.5",
     description="",
     url="https://github.com/AuroraEnergyResearch/aurora-amun-python-sdk",
     author="Aurora Development team",

--- a/tests/snapshots/snap_test_load_factors.py
+++ b/tests/snapshots/snap_test_load_factors.py
@@ -26,10 +26,9 @@ snapshots['test_v1_and_v2_calculations result_v1'] = {
         'obstacleHeight': 0,
         'p50GrossProduction': 0.4,
         'regionCode': 'aus_qld',
-        'roughnessLength': 0.02,
         'smoothingCoefficient': None,
         'startTimeUTC': '2018-01-01T00:00:00.000Z',
-        'turbineModelId': 268,
+        'turbineModelId': 280,
         'usePowerCurveSmoothing': False,
         'windType': 'P50Scaling'
     },

--- a/tests/snapshots/snap_test_load_factors.py
+++ b/tests/snapshots/snap_test_load_factors.py
@@ -28,7 +28,7 @@ snapshots['test_v1_and_v2_calculations result_v1'] = {
         'regionCode': 'aus_qld',
         'smoothingCoefficient': None,
         'startTimeUTC': '2018-01-01T00:00:00.000Z',
-        'turbineModelId': 280,
+        'turbineModelId': 268,
         'usePowerCurveSmoothing': False,
         'windType': 'P50Scaling'
     },

--- a/tests/test_load_factors.py
+++ b/tests/test_load_factors.py
@@ -29,7 +29,6 @@ def test_era5(amun_session):
         lossesAvailability=0.1,
         lossesWake=0,
         numberOfTurbines=12,
-        roughnessLength=0.02,
         usePowerCurveSmoothing=False
     )
     result = amun_session.run_load_factor_for_parameters(flow_parameters, base_parameters)
@@ -55,7 +54,6 @@ def test_era5_with_bad_base_parameters(amun_session):
         lossesAvailability=0.1,
         lossesWake=0,
         numberOfTurbines=12,
-        roughnessLength=0.02,
         usePowerCurveSmoothing=False
     )
 
@@ -87,7 +85,6 @@ def test_average_wind_speed_with_bad_flow_parameters(amun_session):
         lossesAvailability=0.1,
         lossesWake=0,
         numberOfTurbines=12,
-        roughnessLength=0.02,
         usePowerCurveSmoothing=False
     )
 
@@ -125,7 +122,6 @@ def test_bulk_calculation(amun_session):
         lossesAvailability=0.1,
         lossesWake=0,
         numberOfTurbines=12,
-        roughnessLength=0.02,
         usePowerCurveSmoothing=False
     )
 
@@ -155,7 +151,6 @@ def test_v1_and_v2_calculations(amun_session, snapshot):
         lossesAvailability=0.1,
         lossesWake=0,
         numberOfTurbines=12,
-        roughnessLength=0.02,
         usePowerCurveSmoothing=False
     )
 
@@ -188,7 +183,6 @@ def test_unsupported_version(amun_session):
         lossesAvailability=0.1,
         lossesWake=0,
         numberOfTurbines=12,
-        roughnessLength=0.02,
         usePowerCurveSmoothing=False
     )
 


### PR DESCRIPTION
Remove unused parameter `roughnessLength` from loadFactor as it is not used.
Update tests
Update examples
Update SDK version in setup.py
Update SDK changelog
Regenerate pydoc

Fixes: [PAN-1572](https://auroraenergy.atlassian.net/browse/PAN-1572)

[PAN-1572]: https://auroraenergy.atlassian.net/browse/PAN-1572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ